### PR TITLE
chore(ci): update CI pipeline name to reflect Django tests and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI pipeline
+name: Django CI Pipeline — Tests & Coverage
 on:
   push:
     branches:


### PR DESCRIPTION
This pull request updates the name of the CI pipeline in the `.github/workflows/ci.yml` file to provide more clarity about its purpose.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL1-R1): Renamed the pipeline from "CI pipeline" to "Django CI Pipeline — Tests & Coverage" for improved clarity and specificity.